### PR TITLE
Add { } curly brackets icon to Description fields (fixes #107)

### DIFF
--- a/rpg-docs/client/views/character/features/featureDialog/featureDialog.html
+++ b/rpg-docs/client/views/character/features/featureDialog/featureDialog.html
@@ -68,8 +68,11 @@
 		{{/if}}
 	</div>
 
-	<!--description-->
-	<paper-textarea label="Description" id="featureDescriptionInput" value={{description}}></paper-textarea>
+	<!--Description-->
+	<div class=description-input>
+		<paper-textarea id="featureDescriptionInput" label="Description" value={{description}}></paper-textarea>
+		{{> textareaBracketSuffix}}
+	</div>
 
 	{{> effectsEditList parentId=_id parentCollection="Features" charId=charId name=name enabled=enabled}}
 	{{> proficiencyEditList parentId=_id parentCollection="Features" charId=charId enabled=enabled}}

--- a/rpg-docs/client/views/character/inventory/itemDialog/itemDialog.html
+++ b/rpg-docs/client/views/character/inventory/itemDialog/itemDialog.html
@@ -61,12 +61,10 @@
 	</div>
 
 	<!--Description-->
-	<paper-textarea id="itemDescriptionInput" label="Description" value={{description}}>
-		<div suffix>
-			<paper-tooltip position="left" animation-delay="0">This field accepts formulae in {curly brackets}</paper-tooltip>
-			<iron-icon icon="dicecloud:code-braces"></iron-icon>
-		</div>
-	</paper-textarea>
+	<div class=description-input>
+		<paper-textarea id="itemDescriptionInput" label="Description" value={{description}}></paper-textarea>
+		{{> textareaBracketSuffix}}
+	</div>
 	<!--Effects-->
 	{{> effectsEditList parentId=_id parentCollection="Items" charId=charId enabled=equipped name=name}}
 	<!--Attacks-->

--- a/rpg-docs/client/views/character/spells/spellDialog/spellDialog.html
+++ b/rpg-docs/client/views/character/spells/spellDialog/spellDialog.html
@@ -111,8 +111,10 @@
 		</paper-checkbox>
 	</div>
 
-	<!--Description-->
-	<paper-textarea id="descriptionInput" label="Description" value="{{description}}">
-	</paper-textarea>
+	<div class=description-input>
+		<paper-textarea id="descriptionInput" label="Description" value={{description}}></paper-textarea>
+		{{> textareaBracketSuffix}}
+	</div>
+
 	{{> attackEditList  parentId=_id parentCollection="Spells" charId=charId enabled=true name=name}}
 </template>

--- a/rpg-docs/client/views/paperTemplates/inputSuffixes/inputSuffixes.css
+++ b/rpg-docs/client/views/paperTemplates/inputSuffixes/inputSuffixes.css
@@ -1,0 +1,10 @@
+.textarea-bracket-suffix {
+	float: right;
+	position: absolute;
+	right: 6px;
+	bottom: 12px;
+}	
+
+.description-input {
+	position: relative;
+}

--- a/rpg-docs/client/views/paperTemplates/inputSuffixes/inputSuffixes.html
+++ b/rpg-docs/client/views/paperTemplates/inputSuffixes/inputSuffixes.html
@@ -11,3 +11,10 @@
 		<iron-icon icon="dicecloud:code-braces"></iron-icon>
 	</div>
 </template>
+
+<template name="textareaBracketSuffix">
+	<div class="textarea-bracket-suffix">
+		<paper-tooltip position="left" animation-delay="0">This field accepts formulae in {curly brackets}</paper-tooltip>
+		<iron-icon icon="dicecloud:code-braces"></iron-icon>
+	</div>
+</template>


### PR DESCRIPTION
This is a sort of hacky fix to #107 - the text doesn't wrap around it, as I've just wrapped the `<paper-input>` in a `<div>` and given the icon a `position: absolute` in the bottom-right corner of said `<div>`, so it just renders over the top of any text. (This only ever affects the last line of the text though, so it's less of an issue.)