### PR TITLE
Added ability to "unshare" a character.

### DIFF
--- a/rpg-docs/client/views/character/characterSettings/unshareCharacterConfirmation.html
+++ b/rpg-docs/client/views/character/characterSettings/unshareCharacterConfirmation.html
@@ -1,0 +1,23 @@
+<!-- shamelessly nicked and renamed from deleteCharacterConfirmation.html -->
+<template name="unshareCharacterConfirmation">
+	<div class="fit layout vertical">
+		<app-header-layout has-scrolling-region class="feedback flex">
+			<app-header fixed effects="waterfall">
+				<app-toolbar>
+				  <div main-title>Unshare Character</div>
+				</app-toolbar>
+			</app-header>
+			<div class="form flex">
+				Removing (unsharing) a character does not delete it.<br>
+				However, you will be no longer be able to access or view it, unless it is publicly visible.<br>
+				The character's owner or anyone with write permissions for the character can return read access.<br><br>
+				To continue type "{{name}}" into the box below.<br>
+				<paper-input id="nameInput" label="type the characters's name here" style="width: 100%;"></paper-input><br>
+				<paper-button id="unshareButton" style={{getStyle}} disabled={{cantUnshare}}>Unshare Character</paper-button>
+			</div>
+		</app-header-layout>
+		<div class="buttons layout horizontal end-justified">
+			<paper-button class="cancelButton"> Cancel </paper-button>
+		</div>
+	</div>
+</template>

--- a/rpg-docs/client/views/character/characterSettings/unshareCharacterConfirmation.js
+++ b/rpg-docs/client/views/character/characterSettings/unshareCharacterConfirmation.js
@@ -1,0 +1,31 @@
+Template.unshareCharacterConfirmation.onCreated(function() {
+	this.canUnshare = new ReactiveVar(false);
+});
+
+Template.unshareCharacterConfirmation.helpers({
+	cantUnshare: function() {
+		return !Template.instance().canUnshare.get();
+	},
+	getStyle: function() {
+		if (Template.instance().canUnshare.get()) {
+			return "background: #d23f31; color: white;";
+		}
+	}
+});
+
+Template.unshareCharacterConfirmation.events({
+	"change #nameInput, input #nameInput": function(event, instance) {
+		var can = instance.find("#nameInput").value === this.name;
+		instance.canUnshare.set(can);
+	},
+	"click #unshareButton": function(event, instance) {
+		if (instance.find("#nameInput").value === this.name) {
+			setTimeout(popDialogStack, 100); //weird things happen without the delay.
+			Router.go("/characterList");
+			Meteor.call("removeMeFromReaders", this._id);
+		}
+	},
+	"click .cancelButton": function(event, instance){
+		popDialogStack();
+	},
+});

--- a/rpg-docs/client/views/character/characterSheet.html
+++ b/rpg-docs/client/views/character/characterSheet.html
@@ -30,6 +30,16 @@
 								</paper-icon-item>
 							</paper-menu>
 						</paper-menu-button>
+					{{else}}
+						<paper-menu-button class="character-menu" horizontal-align="right">
+							<paper-icon-button icon="more-vert"  class="dropdown-trigger"></paper-icon-button>
+							<paper-menu class="dropdown-content black87">
+								<paper-icon-item id="unshareCharacter">
+									<iron-icon icon="delete" item-icon></iron-icon>
+									Unshare
+								</paper-icon-item>
+							</paper-menu>
+						</paper-menu-button>
 					{{/if}}
 				</div>
 				<div bottom-item>

--- a/rpg-docs/client/views/character/characterSheet.js
+++ b/rpg-docs/client/views/character/characterSheet.js
@@ -210,4 +210,11 @@ Template.characterSheet.events({
 			element: event.currentTarget.parentElement.parentElement,
 		});
 	},
+	"click #unshareCharacter": function(event, instance){
+		pushDialogStack({
+			data: this,
+			template: "unshareCharacterConfirmation",
+			element: event.currentTarget.parentElement.parentElement,
+		});
+	},
 });

--- a/rpg-docs/lib/methods/removeMeFromReaders.js
+++ b/rpg-docs/lib/methods/removeMeFromReaders.js
@@ -1,0 +1,11 @@
+Meteor.methods({
+	removeMeFromReaders: function(charId) {
+		var userId = Meteor.userId();
+		var character = Characters.findOne(charId);
+
+		if (!character) return;
+		if (!_.contains(character.readers, userId)) return;
+
+		Characters.update(charId, {$pull: {"readers": userId}}); //we don't check write permission as you should always be able to remove youself from readers
+	}
+});


### PR DESCRIPTION
Adds a simple dialog (which I basically just ripped from `deleteCharacterConfirmation` but changed the text) to enable users to "unshare" a character by removing themselves from its `readers`.

Users can already remove themselves from `writers`, since by being on that list they have write permissions.

Closes #125.