### PR TITLE
[#127] Arrow library items should give 20 arrows rather than one "Arrows (20)"

### DIFF
--- a/dataSources/srd/adventuringGear.json
+++ b/dataSources/srd/adventuringGear.json
@@ -21,32 +21,40 @@
 		"weight": 1
 	},
 	{
-		"name": "Arrows (20)",
-		"plural": "Arrows (20)",
+		"libraryName": "Arrows (20)",
+		"name": "Arrow",
+		"plural": "Arrows",
 		"description": "",
-		"value": 1,
-		"weight": 1
+		"value": 0.05,
+		"weight": 0.05,
+		"quantity": 20
 	},
 	{
-		"name": "Blowgun needles (5)",
-		"plural": "Blowgun needles (5)",
+		"libraryName": "Blowgun needles (5)",
+		"name": "Blowgun needle",
+		"plural": "Blowgun needles",
 		"description": "",
-		"value": 1,
-		"weight": 1
+		"value": 0.2,
+		"weight": 0.2,
+		"quantity": 5
 	},
 	{
-		"name": "Crossbow bolts (20)",
-		"plural": "Crossbow bolts (20)",
+		"libraryName": "Crossbow bolts (20)",
+		"name": "Crossbow bolt",
+		"plural": "Crossbow bolts",
 		"description": "",
-		"value": 1,
-		"weight": 1.5
+		"value": 0.05,
+		"weight": 0.075,
+		"quantity": 20
 	},
 	{
-		"name": "Sling bullets (20)",
-		"plural": "Sling bullets (20)",
+		"libraryName": "Sling bullets (20)",
+		"name": "Sling bullet",
+		"plural": "Sling bullets",
 		"description": "",
-		"value": 0.04,
-		"weight": 1.5
+		"value": 0.002,
+		"weight": 0.075,
+		"quantity": 20
 	},
 	{
 		"name": "Antitoxin (vial)",
@@ -651,11 +659,13 @@
 		"weight": 3
 	},
 	{
-		"name": "Spikes, iron (10)",
-		"plural": "Spikes, iron (10)",
+		"libraryName": "Spikes, iron (10)",
+		"name": "Spike, iron",
+		"plural": "Spikes, iron",
 		"description": "",
-		"value": 1,
-		"weight": 5
+		"value": 0.1,
+		"weight": 0.5,
+		"quantity": 10
 	},
 	{
 		"name": "Spyglass",

--- a/rpg-docs/Model/Library/LibraryItems.js
+++ b/rpg-docs/Model/Library/LibraryItems.js
@@ -1,6 +1,7 @@
 LibraryItems = new Mongo.Collection("libraryItems");
 
 Schemas.LibraryItems = new SimpleSchema({
+	libraryName:{type: String, optional: true, trim: false},
 	name:       {type: String, defaultValue: "New Item", trim: false},
 	plural:		{type: String, optional: true, trim: false},
 	description:{type: String, optional: true, trim: false},

--- a/rpg-docs/client/views/character/inventory/inventory.js
+++ b/rpg-docs/client/views/character/inventory/inventory.js
@@ -157,7 +157,7 @@ Template.inventory.events({
 					return;
 				}
 				// Make the library item into a regular item
-				let item = _.omit(result, "library", "attacks", "effects");
+				let item = _.omit(result, "libraryName", "library", "attacks", "effects");
 				delete item.settings.category;
 				// Update the item to match library item
 				Items.update(itemId, {$set: item});

--- a/rpg-docs/client/views/character/inventory/itemLibraryDialog/itemLibraryDialog.html
+++ b/rpg-docs/client/views/character/inventory/itemLibraryDialog/itemLibraryDialog.html
@@ -61,15 +61,15 @@
 <template name="libraryItem">
 	<tr class="item library-item {{#if selected}}selected{{/if}}">
 		<td class="itemName">
-			{{item.name}}
+			{{itemName}}
 			<paper-ripple></paper-ripple>
 		</td>
 		<td>
-			{{item.weight}} lb.
+			{{itemWeight}} lb.
 			<paper-ripple></paper-ripple>
  		</td>
 		<td>
-			{{valueString item.value}}
+			{{valueString itemValue}}
 			<paper-ripple></paper-ripple>
 		</td>
 	</tr>

--- a/rpg-docs/client/views/character/inventory/itemLibraryDialog/itemLibraryDialog.js
+++ b/rpg-docs/client/views/character/inventory/itemLibraryDialog/itemLibraryDialog.js
@@ -107,3 +107,24 @@ Template.itemLibraryDialog.events({
 		template.searchTerm.set(value);
 	},
 });
+
+Template.libraryItem.helpers({
+	itemName: function(){
+		return this.item.libraryName || this.item.name;
+	},
+	itemWeight: function(){
+		if (this.item.quantity) {
+			return this.item.weight * this.item.quantity;
+		} else {
+			return this.item.weight;
+		}
+	},
+	itemValue: function(){
+		if (this.item.quantity) {
+			return this.item.value * this.item.quantity;
+		} else {
+			return this.item.value;
+		}
+	},
+
+});


### PR DESCRIPTION
Selecting "Arrows (20)" in the library now gives you 20 arrows. This also works for the other ammunitions (blowgun darts, crossbow bolts, and sling bullets) as well as iron spikes.

The weight and value remain correct for the total - the 20 arrows together are 1gp and 1lb, as each individual arrow is 5cp (0.05gp) and 0.05lb.