### PR TITLE
Removed blank bit of card on features with no short description

### DIFF
--- a/rpg-docs/client/views/character/features/features.css
+++ b/rpg-docs/client/views/character/features/features.css
@@ -6,6 +6,10 @@
 	margin-bottom: 8px;
 }
 
+.card.featureCard .bottom {
+	padding-bottom: 8px;
+}
+
 .containerMain.featureDescription {
 	white-space: pre-line;
 }

--- a/rpg-docs/client/views/character/features/features.html
+++ b/rpg-docs/client/views/character/features/features.html
@@ -78,7 +78,7 @@
 								</div>
 							{{/if}}
 						</div>
-						{{#if description}}
+						{{#if hasCharacters (evaluateShortString charId description)}}
 							<div class="bottom flex">
 								{{#markdown}}{{evaluateShortString charId description}}{{/markdown}}
 							</div>

--- a/rpg-docs/client/views/character/features/features.js
+++ b/rpg-docs/client/views/character/features/features.js
@@ -56,6 +56,9 @@ Template.features.helpers({
 		var profs = Proficiencies.find({charId: this._id, type: "tool"});
 		return removeDuplicateProficiencies(profs);
 	},
+	hasCharacters: function(string){
+		return string.match(/\S/);
+	},
 });
 
 Template.features.events({


### PR DESCRIPTION
![before](https://i.imgur.com/qvVJHUk.png)

Previously, if a feature's description had nothing above the first horizontal rule, the feature card would still display a small bit of white space even though there was nothing to display. 

Now, if the only thing above the first horizontal rule is whitespace, the description area on the card is not rendered at all.

![after](https://i.imgur.com/esuGXKl.png)